### PR TITLE
Clear remaining run_shard CodeQL alert

### DIFF
--- a/src/hermes_katana/proving_ground/run_shard.py
+++ b/src/hermes_katana/proving_ground/run_shard.py
@@ -70,6 +70,23 @@ def _safe_slug(s: str) -> str:
     return s.replace("/", "_").replace(":", "_").replace(" ", "_").replace(".", "-")
 
 
+def _public_api_model_name(model_id: str) -> str:
+    """Return the non-secret provider model name used for result metadata."""
+    m = local_models.MODELS.get(model_id)
+    if not m:
+        return model_id
+    backend = m.get("backend", "llama_cpp")
+    if backend == "openrouter":
+        return str(m.get("openrouter_slug") or model_id)
+    if backend == "minimax":
+        return str(m.get("minimax_slug") or model_id)
+    if backend == "remote_api":
+        return str(m.get("api_model_slug") or model_id)
+    if backend == "ollama":
+        return str(m.get("ollama_tag") or model_id)
+    return model_id
+
+
 def resolve_endpoint(
     model_id: str,
     port: int = 8080,
@@ -295,6 +312,7 @@ async def run(
     if swept.deleted_empty + swept.deleted_stale > 0:
         print(f"    [sweep] {swept.summary()}")
 
+    public_api_model = _public_api_model_name(model_id)
     endpoint = resolve_endpoint(model_id, startup_timeout=startup_timeout, ngl_override=ngl_override)
     if endpoint is None:
         return 1
@@ -390,7 +408,7 @@ async def run(
                     "session_id": result.session_id,
                     "shard": shard_id,
                     "model_id": model_id,
-                    "api_model": api_model,
+                    "api_model": public_api_model,
                     "attack_id": attack.id,
                     "attack_label": attack.label,
                     "task": task_name,


### PR DESCRIPTION
## Summary
- derive persisted `api_model` result metadata from non-secret model registry data
- keep runtime endpoint resolution and API token handling unchanged
- addresses the remaining CodeQL `py/clear-text-storage-sensitive-data` alert in `run_shard.py`

## Verification
- `.venv/bin/python -m ruff check src/hermes_katana/proving_ground/run_shard.py`
- `.venv/bin/python -m ruff format --check src/hermes_katana/proving_ground/run_shard.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src .venv/bin/python -m py_compile src/hermes_katana/proving_ground/run_shard.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected model identifiers displayed in session results to use standardized provider model names

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/claudlos/hermes-katana/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->