### PR TITLE
Fix release SBOM attestation

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -100,7 +100,6 @@ jobs:
             --pyproject pyproject.toml \
             --mc-type library \
             --sv 1.6 \
-            --output-reproducible \
             --of JSON \
             -o dist/sbom/hermes-katana.cdx.json \
             /tmp/katana-wheel-smoke/bin/python


### PR DESCRIPTION
## Summary
- remove CycloneDX reproducible output from the release SBOM generation step
- restore the SBOM serialNumber field required by actions/attest

## Validation
- parsed .github/workflows/release-gate.yml with PyYAML
- ran git diff --check
- reproduced the failing master run error from Release Gate run 26391761920
- generated a local CycloneDX 1.6 SBOM without --output-reproducible and confirmed it includes serialNumber

## Note
The Release Gate workflow skips attestation on pull_request events, so this PR can validate syntax and build behavior but cannot exercise the exact failing attestation step until the fix lands on master.