### PR TITLE
Scrub prefixed subprocess secrets

### DIFF
--- a/src/hermes_katana/proving_ground/sandbox/agent_cli_runner.py
+++ b/src/hermes_katana/proving_ground/sandbox/agent_cli_runner.py
@@ -1944,10 +1944,10 @@ _EXPLICIT_DENY_ENV_KEYS = {
 
 _SENSITIVE_ENV_NAME_RE = re.compile(
     # Catches API_KEY, ACCESS_KEY, KEY, TOKEN, SECRET, PASSWORD, PASSWD,
-    # CREDENTIAL, PRIVATE, AUTH — both as standalone words and as components
+    # CREDENTIAL(S), PRIVATE, AUTH — both as standalone words and as components
     # of compound env names. Terminator covers _, /, -, end-of-string.
     r"(?:^|[_/-])(?:API_KEY|ACCESS_KEY|KEY|TOKEN|SECRET|PASSW(?:OR)?D"
-    r"|CREDENTIAL|PRIVATE|AUTH)(?:[_/-]|$)",
+    r"|CREDENTIALS?|PRIVATE|AUTH)(?:[_/-]|$)",
     re.IGNORECASE,
 )
 
@@ -1955,23 +1955,24 @@ _SENSITIVE_ENV_NAME_RE = re.compile(
 def _env_key_allowed_for_subprocess(key: str) -> bool:
     """Decide whether to pass ``key`` into a CLI-agent subprocess env.
 
-    Allowlist-first: provider keys, core shell vars, and known-safe prefixes
-    pass without further checks. Anything else is dropped if it appears in
-    the explicit deny list or matches the sensitive-name regex. This is
-    *defensive* — the goal is to avoid leaking unrelated ambient credentials
-    (AWS_*, GITHUB_TOKEN, DATABASE_URL, etc.) into a subprocess that doesn't
-    need them. New CLI knobs should be added to ``_ALLOWED_ENV_PREFIXES``.
+    Provider API keys are deliberately allowed for harness drivers that need
+    them. All other variables are denied on sensitive names before broad
+    prefixes are considered, so KATANA_API_KEY/HERMES_SECRET-style ambient
+    credentials cannot bypass the scrubber just because they use an allowed
+    configuration prefix.
     """
     upper = key.upper()
     if upper in _ALLOWED_PROVIDER_SECRET_ENV_KEYS:
         return True
+    if upper in _EXPLICIT_DENY_ENV_KEYS:
+        return False
+    if _SENSITIVE_ENV_NAME_RE.search(upper):
+        return False
     if upper in _CORE_SHELL_ENV_KEYS:
         return True
     if any(upper.startswith(prefix) for prefix in _ALLOWED_ENV_PREFIXES):
         return True
-    if upper in _EXPLICIT_DENY_ENV_KEYS:
-        return False
-    return _SENSITIVE_ENV_NAME_RE.search(upper) is None
+    return True
 
 
 def _warn_if_broken_claude_run(

--- a/src/hermes_katana/proving_ground/sandbox/agent_cli_runner.py
+++ b/src/hermes_katana/proving_ground/sandbox/agent_cli_runner.py
@@ -1874,9 +1874,10 @@ _ALLOWED_PROVIDER_SECRET_ENV_KEYS = {
     "XIAOMI_API_KEY",
 }
 
-# Allowlist of env keys we know are safe to pass into CLI-agent subprocesses.
-# Anything matching this set or matching one of `_ALLOWED_PROVIDER_SECRET_ENV_KEYS`
-# is preserved. Everything else passes through the denylist regex below.
+# Common env keys and prefixes known to be useful for CLI-agent subprocesses.
+# These document the expected non-secret knobs; the scrubber below still allows
+# other non-sensitive names by default to avoid breaking vendor CLIs that probe
+# their environment.
 _CORE_SHELL_ENV_KEYS = {
     "PATH",
     "HOME",
@@ -1958,8 +1959,9 @@ def _env_key_allowed_for_subprocess(key: str) -> bool:
     Provider API keys are deliberately allowed for harness drivers that need
     them. All other variables are denied on sensitive names before broad
     prefixes are considered, so KATANA_API_KEY/HERMES_SECRET-style ambient
-    credentials cannot bypass the scrubber just because they use an allowed
-    configuration prefix.
+    credentials cannot bypass the scrubber just because they use a common
+    configuration prefix. Non-sensitive names are allowed by default for CLI
+    compatibility.
     """
     upper = key.upper()
     if upper in _ALLOWED_PROVIDER_SECRET_ENV_KEYS:
@@ -1968,10 +1970,6 @@ def _env_key_allowed_for_subprocess(key: str) -> bool:
         return False
     if _SENSITIVE_ENV_NAME_RE.search(upper):
         return False
-    if upper in _CORE_SHELL_ENV_KEYS:
-        return True
-    if any(upper.startswith(prefix) for prefix in _ALLOWED_ENV_PREFIXES):
-        return True
     return True
 
 

--- a/tests/proving_ground/test_audit_fixes.py
+++ b/tests/proving_ground/test_audit_fixes.py
@@ -363,7 +363,7 @@ def test_env_scrub_drops_database_url_and_aws_profile(monkeypatch):
 
 
 def test_env_scrub_allows_known_prefixes():
-    """HERMES_*/KATANA_*/XDG_* etc. must pass through (allowlist intent)."""
+    """HERMES_*/KATANA_*/XDG_* etc. must pass through for CLI compatibility."""
     for key in (
         "HERMES_TEMPERATURE",
         "KATANA_PROXY_URL",
@@ -373,6 +373,12 @@ def test_env_scrub_allows_known_prefixes():
         "VIRTUAL_ENV",
     ):
         assert _env_key_allowed_for_subprocess(key), f"{key} should pass the allowlist"
+
+
+def test_env_scrub_allows_unknown_non_sensitive_names():
+    """Unknown env names pass unless they are explicitly denied or look sensitive."""
+    for key in ("CI", "TERM_PROGRAM", "CUSTOM_AGENT_FEATURE_FLAG"):
+        assert _env_key_allowed_for_subprocess(key), f"{key} should pass by default"
 
 
 def test_env_scrub_drops_sensitive_names_under_allowed_prefixes(monkeypatch):

--- a/tests/proving_ground/test_audit_fixes.py
+++ b/tests/proving_ground/test_audit_fixes.py
@@ -301,6 +301,39 @@ def test_env_scrub_allows_known_prefixes():
         assert _env_key_allowed_for_subprocess(key), f"{key} should pass the allowlist"
 
 
+def test_env_scrub_drops_sensitive_names_under_allowed_prefixes(monkeypatch):
+    """Broad config prefixes must not let ambient secret-looking env vars through."""
+    for key in (
+        "KATANA_API_KEY",
+        "HERMES_SECRET",
+        "OPENAI_SESSION_TOKEN",
+        "PYTHON_AUTH_TOKEN",
+        "XDG_CREDENTIAL_FILE",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    ):
+        assert not _env_key_allowed_for_subprocess(key), f"{key} should be dropped"
+        monkeypatch.setenv(key, "do-not-leak")
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.example.test/v1")
+    monkeypatch.setenv("HERMES_TEMPERATURE", "0")
+    monkeypatch.setenv("OPENAI_API_KEY", "provider-key-needed-by-harness")
+
+    env = _build_subprocess_env(AGENT_DRIVERS["hermes_minimax_m2_7"])
+
+    for key in (
+        "KATANA_API_KEY",
+        "HERMES_SECRET",
+        "OPENAI_SESSION_TOKEN",
+        "PYTHON_AUTH_TOKEN",
+        "XDG_CREDENTIAL_FILE",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    ):
+        assert env.get(key) is None, f"{key} leaked into subprocess env"
+    assert env.get("OPENAI_BASE_URL") == "https://api.example.test/v1"
+    assert env.get("HERMES_TEMPERATURE") == "0"
+    assert env.get("OPENAI_API_KEY") == "provider-key-needed-by-harness"
+
+
 def test_env_scrub_drops_aws_secret_and_github_token():
     """Sensitive-name pattern still catches the standard suspects."""
     for key in (


### PR DESCRIPTION
## Summary
- deny sensitive-looking environment variable names before applying broad allowed prefixes
- keep explicit provider API keys available for harness drivers that need them
- add regression coverage for KATANA_API_KEY/HERMES_SECRET/OPENAI_SESSION_TOKEN-style leaks while preserving safe config knobs

## Verification
- .venv/bin/python -m pytest tests/proving_ground/test_audit_fixes.py tests/proving_ground/test_agent_cli_runner.py -q --tb=short
- .venv/bin/python -m ruff check src/hermes_katana/proving_ground/sandbox/agent_cli_runner.py tests/proving_ground/test_audit_fixes.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security filtering of environment variables passed to subprocesses. Improved detection and removal of sensitive variables such as credentials, passwords, and authentication tokens, including those using common allowed prefixes, to prevent accidental credential exposure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/claudlos/hermes-katana/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->