### PR TITLE
Reject symlinked Katana install state

### DIFF
--- a/src/hermes_katana/installer/installer.py
+++ b/src/hermes_katana/installer/installer.py
@@ -285,18 +285,25 @@ class KatanaInstaller:
 
     def _validate_checkout_local_path(self, target: Path, path: Path, label: str) -> None:
         """Reject symlink/traversal paths before writing checkout-local state."""
-        if path.is_symlink():
+        try:
+            is_symlink = path.is_symlink()
+        except OSError as exc:
+            raise ValueError(f"{label} path could not be validated: {path}") from exc
+        if is_symlink:
             raise ValueError(f"{label} path is a symlink: {path}")
         try:
             path.resolve(strict=False).relative_to(target.resolve())
-        except ValueError:
-            raise ValueError(f"{label} path escapes checkout: {path}")
+        except ValueError as exc:
+            raise ValueError(f"{label} path escapes checkout: {path}") from exc
+        except (OSError, RuntimeError) as exc:
+            raise ValueError(f"{label} path could not be validated: {path}") from exc
 
     def _ensure_checkout_local_dir(self, target: Path, relative: str | Path, label: str) -> Path:
         """Create a checkout-local directory after rejecting symlink escapes."""
         path = target / relative
         self._validate_checkout_local_path(target, path, label)
         path.mkdir(parents=True, exist_ok=True)
+        self._validate_checkout_local_path(target, path, label)
         return path
 
     def detect_hermes(self, path: str | Path) -> bool:
@@ -758,7 +765,11 @@ class KatanaInstaller:
         """Create a file snapshot and manifest for install or uninstall."""
         if backup_dir is None:
             timestamp = time.strftime("%Y%m%d-%H%M%S", time.gmtime())
-            root = target / KATANA_BACKUP_DIR / f"{operation}-{timestamp}"
+            root = self._ensure_checkout_local_dir(
+                target,
+                Path(KATANA_BACKUP_DIR) / f"{operation}-{timestamp}",
+                "Backup directory",
+            )
         else:
             root = Path(backup_dir).expanduser().resolve()
 
@@ -769,11 +780,16 @@ class KatanaInstaller:
         copied: list[str] = []
 
         for source in paths:
+            self._validate_checkout_local_path(target, source, "Backup source")
             relative = source.relative_to(target)
             destination = root / relative
+            if backup_dir is None:
+                self._validate_checkout_local_path(target, destination, "Backup destination")
 
             if source.is_dir():
-                shutil.copytree(source, destination, dirs_exist_ok=True)
+                for nested in source.rglob("*"):
+                    self._validate_checkout_local_path(target, nested, "Backup source")
+                shutil.copytree(source, destination, dirs_exist_ok=True, symlinks=True)
             else:
                 destination.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(source, destination)
@@ -789,6 +805,8 @@ class KatanaInstaller:
             missing_paths=sorted(self._missing_paths_for_backup(target, operation)),
         )
         manifest_path = root / KATANA_BACKUP_MANIFEST
+        if backup_dir is None:
+            self._validate_checkout_local_path(target, manifest_path, "Backup manifest")
         manifest_path.write_text(json.dumps(manifest.to_dict(), indent=2), encoding="utf-8")
         return manifest
 

--- a/src/hermes_katana/installer/installer.py
+++ b/src/hermes_katana/installer/installer.py
@@ -283,6 +283,22 @@ class KatanaInstaller:
             layout = "current"
         return LEGACY_CORE_PATCHES if layout == "legacy-v0.1.0" else CURRENT_CORE_PATCHES
 
+    def _validate_checkout_local_path(self, target: Path, path: Path, label: str) -> None:
+        """Reject symlink/traversal paths before writing checkout-local state."""
+        if path.is_symlink():
+            raise ValueError(f"{label} path is a symlink: {path}")
+        try:
+            path.resolve(strict=False).relative_to(target.resolve())
+        except ValueError:
+            raise ValueError(f"{label} path escapes checkout: {path}")
+
+    def _ensure_checkout_local_dir(self, target: Path, relative: str | Path, label: str) -> Path:
+        """Create a checkout-local directory after rejecting symlink escapes."""
+        path = target / relative
+        self._validate_checkout_local_path(target, path, label)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
     def detect_hermes(self, path: str | Path) -> bool:
         """Check if the given path is a Hermes checkout.
 
@@ -404,8 +420,7 @@ class KatanaInstaller:
             logger.info("Created install backup at %s", manifest.backup_root)
 
         # 1. Create .katana directory
-        katana_dir = target / KATANA_CONFIG_DIR
-        katana_dir.mkdir(exist_ok=True)
+        katana_dir = self._ensure_checkout_local_dir(target, KATANA_CONFIG_DIR, "Config directory")
         logger.debug("Created config dir: %s", katana_dir)
 
         # 2. Generate configuration
@@ -794,8 +809,9 @@ class KatanaInstaller:
         Does not overwrite an existing config file — preserves user
         customizations.
         """
-        config_dir = target / KATANA_CONFIG_DIR
+        config_dir = self._ensure_checkout_local_dir(target, KATANA_CONFIG_DIR, "Config directory")
         config_file = config_dir / KATANA_CONFIG_FILE
+        self._validate_checkout_local_path(target, config_file, "Config file")
 
         if config_file.exists():
             logger.debug("Config file already exists, skipping: %s", config_file)
@@ -813,7 +829,7 @@ class KatanaInstaller:
         logger.info("Generated config: %s", config_file)
 
         # Create audit directory
-        (config_dir / "audit").mkdir(exist_ok=True)
+        self._ensure_checkout_local_dir(target, Path(KATANA_CONFIG_DIR) / "audit", "Audit directory")
 
     def _generate_ca_cert(self, target: Path) -> None:
         """Generate a CA certificate for the MITM proxy.
@@ -821,11 +837,18 @@ class KatanaInstaller:
         Uses the ``cryptography`` library to create a self-signed CA
         certificate and private key.  Skips if the cert already exists.
         """
-        cert_dir = target / KATANA_CONFIG_DIR / KATANA_CA_DIR
-        cert_dir.mkdir(parents=True, exist_ok=True)
+        cert_dir = self._ensure_checkout_local_dir(
+            target,
+            Path(KATANA_CONFIG_DIR) / KATANA_CA_DIR,
+            "CA certificate directory",
+        )
 
         cert_path = cert_dir / KATANA_CA_CERT
         key_path = cert_dir / KATANA_CA_KEY
+        salt_path = cert_dir / "ca_salt.txt"
+        self._validate_checkout_local_path(target, cert_path, "CA certificate")
+        self._validate_checkout_local_path(target, key_path, "CA private key")
+        self._validate_checkout_local_path(target, salt_path, "CA salt")
 
         if cert_path.exists() and key_path.exists():
             logger.debug("CA cert already exists, skipping: %s", cert_path)
@@ -889,7 +912,6 @@ class KatanaInstaller:
             import secrets as _secrets
 
             ca_salt = _secrets.token_hex(16)
-            salt_path = cert_dir / "ca_salt.txt"
             salt_path.write_text(ca_salt, encoding="utf-8")
             passphrase = hashlib.sha256(f"katana-{target}-{ca_salt}".encode()).hexdigest()[:32].encode()
 
@@ -919,6 +941,7 @@ class KatanaInstaller:
     def _write_marker(self, target: Path, results: list[PatchResult]) -> None:
         """Write the install marker file with metadata."""
         marker = target / KATANA_INSTALL_MARKER
+        self._validate_checkout_local_path(target, marker, "Install marker")
         data = {
             "installed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "installer_version": __version__,

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -16,7 +16,12 @@ from pathlib import Path
 
 import pytest
 
-from hermes_katana.installer.installer import KATANA_CONFIG_DIR, KATANA_CONFIG_FILE, KatanaInstaller
+from hermes_katana.installer.installer import (
+    KATANA_BACKUP_DIR,
+    KATANA_CONFIG_DIR,
+    KATANA_CONFIG_FILE,
+    KatanaInstaller,
+)
 from hermes_katana.installer.patches import (
     CURRENT_CORE_PATCHES,
     LEGACY_CORE_PATCHES,
@@ -237,6 +242,35 @@ class TestInstallerLifecycle:
             KatanaInstaller().install(checkout)
 
         assert outside_config.read_text(encoding="utf-8") == "outside: true\n"
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows symlink creation requires admin or Developer Mode.",
+    )
+    def test_install_backup_rejects_symlinked_katana_source(self, tmp_dir):
+        checkout = fixture_checkout_direct(HERMES_CURRENT_SNAPSHOT, tmp_dir)
+        outside = tmp_dir / "outside-katana"
+        outside.mkdir()
+        (outside / KATANA_CONFIG_FILE).write_text("outside: true\n", encoding="utf-8")
+        (checkout / KATANA_CONFIG_DIR).symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="Backup source path is a symlink"):
+            KatanaInstaller().install(checkout, backup=True)
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows symlink creation requires admin or Developer Mode.",
+    )
+    def test_install_backup_rejects_symlinked_backup_dir(self, tmp_dir):
+        checkout = fixture_checkout_direct(HERMES_CURRENT_SNAPSHOT, tmp_dir)
+        outside = tmp_dir / "outside-backups"
+        outside.mkdir()
+        (checkout / KATANA_BACKUP_DIR).symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="Backup directory path escapes checkout"):
+            KatanaInstaller().install(checkout, backup=True)
+
+        assert not any(outside.iterdir())
 
     def test_uninstall_backup_survives_removed_checkout_state(self, monkeypatch, tmp_dir):
         checkout = fixture_checkout(HERMES_V010_EXTENDED_SNAPSHOT, tmp_dir)

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from hermes_katana.installer.installer import KatanaInstaller
+from hermes_katana.installer.installer import KATANA_CONFIG_DIR, KATANA_CONFIG_FILE, KatanaInstaller
 from hermes_katana.installer.patches import (
     CURRENT_CORE_PATCHES,
     LEGACY_CORE_PATCHES,
@@ -205,6 +205,38 @@ class TestInstallerLifecycle:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         assert manifest["operation"] == "install"
         assert "hermes/tools/dispatch.py" in manifest["files"]
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows symlink creation requires admin or Developer Mode.",
+    )
+    def test_install_rejects_symlinked_katana_dir(self, tmp_dir):
+        checkout = fixture_checkout_direct(HERMES_CURRENT_SNAPSHOT, tmp_dir)
+        outside = tmp_dir / "outside-katana"
+        outside.mkdir()
+        (checkout / KATANA_CONFIG_DIR).symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="Config directory path is a symlink"):
+            KatanaInstaller().install(checkout)
+
+        assert not (outside / KATANA_CONFIG_FILE).exists()
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows symlink creation requires admin or Developer Mode.",
+    )
+    def test_install_rejects_symlinked_katana_config_file(self, tmp_dir):
+        checkout = fixture_checkout_direct(HERMES_CURRENT_SNAPSHOT, tmp_dir)
+        config_dir = checkout / KATANA_CONFIG_DIR
+        config_dir.mkdir()
+        outside_config = tmp_dir / "outside.yaml"
+        outside_config.write_text("outside: true\n", encoding="utf-8")
+        (config_dir / KATANA_CONFIG_FILE).symlink_to(outside_config)
+
+        with pytest.raises(ValueError, match="Config file path is a symlink"):
+            KatanaInstaller().install(checkout)
+
+        assert outside_config.read_text(encoding="utf-8") == "outside: true\n"
 
     def test_uninstall_backup_survives_removed_checkout_state(self, monkeypatch, tmp_dir):
         checkout = fixture_checkout(HERMES_V010_EXTENDED_SNAPSHOT, tmp_dir)


### PR DESCRIPTION
## Summary
- reject symlinked checkout-local install paths before writing .katana state, CA material, audit dirs, or install markers
- fail closed on symlinked .katana directories and symlinked katana.yaml files
- add installer regression tests proving outside symlink targets are not written

## Verification
- .venv/bin/python -m pytest tests/unit/test_installer.py tests/unit/test_bootstrap.py -q --tb=short
- .venv/bin/python -m ruff check src/hermes_katana/installer/installer.py tests/unit/test_installer.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened installer security by preventing symlink-based attacks and path escape vulnerabilities
  * Installer now validates and rejects symlinked configuration directories and backup paths
  * Enhanced path validation across all checkout-local file and directory creation operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/claudlos/hermes-katana/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->