### PR TITLE
Bound proxy content decoding by scan cap

### DIFF
--- a/src/hermes_katana/proxy/addon.py
+++ b/src/hermes_katana/proxy/addon.py
@@ -223,19 +223,37 @@ class KatanaAddon:
 
     @staticmethod
     def _decompress_with_limit(data: bytes, wbits: int, max_output_size: int) -> tuple[bytes, bool]:
-        """Decompress one stream without producing more than max_output_size bytes."""
-        decompressor = zlib.decompressobj(wbits)
-        if max_output_size <= 0:
-            return decompressor.decompress(data) + decompressor.flush(), False
+        """Decompress concatenated streams without producing more than max_output_size bytes."""
+        decoded = bytearray()
+        remaining_input = data
 
-        decoded = decompressor.decompress(data, max_output_size + 1)
-        oversized = len(decoded) > max_output_size or bool(decompressor.unconsumed_tail)
-        if len(decoded) <= max_output_size:
-            remaining = max_output_size + 1 - len(decoded)
-            tail = decompressor.flush(remaining)
-            decoded += tail
-            oversized = oversized or len(decoded) > max_output_size
-        return decoded[:max_output_size], oversized
+        while remaining_input:
+            decompressor = zlib.decompressobj(wbits)
+            if max_output_size <= 0:
+                decoded.extend(decompressor.decompress(remaining_input))
+                decoded.extend(decompressor.flush())
+            else:
+                allowance = max_output_size + 1 - len(decoded)
+                if allowance <= 0:
+                    return bytes(decoded[:max_output_size]), True
+                decoded.extend(decompressor.decompress(remaining_input, allowance))
+                if decompressor.unconsumed_tail:
+                    return bytes(decoded[:max_output_size]), True
+                allowance = max_output_size + 1 - len(decoded)
+                if allowance > 0:
+                    decoded.extend(decompressor.flush(allowance))
+                if len(decoded) > max_output_size:
+                    return bytes(decoded[:max_output_size]), True
+
+            if not decompressor.eof:
+                raise zlib.error("incomplete compressed stream")
+            if not decompressor.unused_data:
+                break
+            remaining_input = decompressor.unused_data
+
+        if max_output_size > 0 and len(decoded) > max_output_size:
+            return bytes(decoded[:max_output_size]), True
+        return bytes(decoded), False
 
     @classmethod
     def _decode_content_encoding(

--- a/src/hermes_katana/proxy/addon.py
+++ b/src/hermes_katana/proxy/addon.py
@@ -18,7 +18,6 @@ __all__ = [
 ]
 
 import hashlib
-import gzip
 import logging
 import threading
 import time
@@ -223,24 +222,60 @@ class KatanaAddon:
         return False
 
     @staticmethod
-    def _decode_content_encoding(data: bytes, content_encoding: str) -> bytes:
-        """Decode supported HTTP content encodings before scanning."""
+    def _decompress_with_limit(data: bytes, wbits: int, max_output_size: int) -> tuple[bytes, bool]:
+        """Decompress one stream without producing more than max_output_size bytes."""
+        decompressor = zlib.decompressobj(wbits)
+        if max_output_size <= 0:
+            return decompressor.decompress(data) + decompressor.flush(), False
+
+        decoded = decompressor.decompress(data, max_output_size + 1)
+        oversized = len(decoded) > max_output_size or bool(decompressor.unconsumed_tail)
+        if len(decoded) <= max_output_size:
+            remaining = max_output_size + 1 - len(decoded)
+            tail = decompressor.flush(remaining)
+            decoded += tail
+            oversized = oversized or len(decoded) > max_output_size
+        return decoded[:max_output_size], oversized
+
+    @classmethod
+    def _decode_content_encoding(
+        cls,
+        data: bytes,
+        content_encoding: str,
+        *,
+        max_output_size: int = 0,
+    ) -> tuple[bytes, bool]:
+        """Decode supported HTTP content encodings before scanning.
+
+        Returns the decoded bytes plus a flag indicating whether decoding was
+        truncated at max_output_size. This prevents gzip/deflate bodies from
+        expanding unboundedly before the proxy scan cap is applied.
+        """
         decoded = data
+        oversized = False
         encodings = [entry.strip().lower() for entry in content_encoding.split(",") if entry.strip()]
         for encoding in reversed(encodings):
             if encoding == "identity":
                 continue
             if encoding == "gzip":
-                decoded = gzip.decompress(decoded)
+                decoded, oversized = cls._decompress_with_limit(
+                    decoded,
+                    16 + zlib.MAX_WBITS,
+                    max_output_size,
+                )
+                if oversized:
+                    break
                 continue
             if encoding == "deflate":
                 try:
-                    decoded = zlib.decompress(decoded)
+                    decoded, oversized = cls._decompress_with_limit(decoded, zlib.MAX_WBITS, max_output_size)
                 except zlib.error:
-                    decoded = zlib.decompress(decoded, -zlib.MAX_WBITS)
+                    decoded, oversized = cls._decompress_with_limit(decoded, -zlib.MAX_WBITS, max_output_size)
+                if oversized:
+                    break
                 continue
             raise ValueError(f"Unsupported content encoding: {encoding}")
-        return decoded
+        return decoded, oversized
 
     def _collect_scan_vault_values(self, *, extra_values: Iterable[str] = ()) -> Optional[set[str]]:
         """Collect vault secrets for the current scan without keeping a long-lived plaintext cache."""
@@ -266,8 +301,11 @@ class KatanaAddon:
             content_type = ""
             content_encoding = ""
 
-        decoded_body = self._decode_content_encoding(body, content_encoding)
-        decoded_oversized = False
+        decoded_body, decoded_oversized = self._decode_content_encoding(
+            body,
+            content_encoding,
+            max_output_size=self.config.max_body_scan_size,
+        )
         if self.config.max_body_scan_size and len(decoded_body) > self.config.max_body_scan_size:
             decoded_body = decoded_body[: self.config.max_body_scan_size]
             decoded_oversized = True

--- a/tests/unit/test_proxy_size_gates.py
+++ b/tests/unit/test_proxy_size_gates.py
@@ -9,6 +9,8 @@ when the body was oversized but allowed through in permissive mode.
 
 from __future__ import annotations
 
+import gzip
+import zlib
 
 from hermes_katana.proxy.addon import KatanaAddon
 from hermes_katana.proxy.config import ProxyConfig
@@ -136,3 +138,33 @@ def test_content_length_helper_parses_string_and_int():
     assert KatanaAddon._content_length(_Headers({})) is None
     assert KatanaAddon._content_length(_Headers({"Content-Length": "garbage"})) is None
     assert KatanaAddon._content_length(None) is None
+
+
+def test_gzip_decode_is_bounded_by_scan_cap():
+    addon = _addon(max_body_scan_size=128)
+    payload = b"A" * (2 * 1024 * 1024)
+    compressed = gzip.compress(payload, compresslevel=9)
+
+    decoded, _content_type, oversized = addon._decode_body_for_scan(
+        compressed,
+        _Headers({"content-type": "text/plain", "content-encoding": "gzip"}),
+    )
+
+    assert len(compressed) < len(payload)
+    assert decoded == payload[:128]
+    assert oversized is True
+
+
+def test_deflate_decode_is_bounded_by_scan_cap():
+    addon = _addon(max_body_scan_size=128)
+    payload = b"A" * (2 * 1024 * 1024)
+    compressed = zlib.compress(payload, level=9)
+
+    decoded, _content_type, oversized = addon._decode_body_for_scan(
+        compressed,
+        _Headers({"content-type": "text/plain", "content-encoding": "deflate"}),
+    )
+
+    assert len(compressed) < len(payload)
+    assert decoded == payload[:128]
+    assert oversized is True

--- a/tests/unit/test_proxy_size_gates.py
+++ b/tests/unit/test_proxy_size_gates.py
@@ -155,6 +155,20 @@ def test_gzip_decode_is_bounded_by_scan_cap():
     assert oversized is True
 
 
+def test_gzip_decode_scans_concatenated_members():
+    addon = _addon(max_body_scan_size=1024)
+    payload = b"first member\nsecond member"
+    compressed = gzip.compress(b"first member\n") + gzip.compress(b"second member")
+
+    decoded, _content_type, oversized = addon._decode_body_for_scan(
+        compressed,
+        _Headers({"content-type": "text/plain", "content-encoding": "gzip"}),
+    )
+
+    assert decoded == payload
+    assert oversized is False
+
+
 def test_deflate_decode_is_bounded_by_scan_cap():
     addon = _addon(max_body_scan_size=128)
     payload = b"A" * (2 * 1024 * 1024)


### PR DESCRIPTION
## Summary
- decode gzip and deflate bodies through bounded zlib decompressors
- preserve the partial-scan marker when decoded content exceeds max_body_scan_size
- add regressions for compressed bodies that expand beyond the scan cap

## Verification
- .venv/bin/python -m pytest tests/unit/test_proxy_size_gates.py tests/test_proxy_addon.py tests/unit/test_proxy_header_scanning.py -q --tb=short
- .venv/bin/python -m ruff check src/hermes_katana/proxy/addon.py tests/unit/test_proxy_size_gates.py tests/test_proxy_addon.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Compressed request and response bodies with gzip or deflate encoding are now properly bounded by configurable maximum size limits during content analysis. Large encoded payloads are correctly truncated to prevent excessive resource consumption, significantly enhancing system reliability and ensuring more stable and predictable behavior throughout scanning operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/claudlos/hermes-katana/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->