### PR TITLE
Reject unsafe runtime artifact paths

### DIFF
--- a/src/hermes_katana/runtime_artifacts.py
+++ b/src/hermes_katana/runtime_artifacts.py
@@ -22,7 +22,9 @@ def runtime_artifact_manifest_path() -> Path:
 
 
 def _safe_manifest_path(rel_path: str) -> bool:
-    if not rel_path or rel_path.startswith("/") or "\\" in rel_path:
+    if not rel_path or rel_path.startswith("/") or "\\" in rel_path or "\x00" in rel_path:
+        return False
+    if len(rel_path) >= 2 and rel_path[1] == ":":
         return False
     return ".." not in PurePosixPath(rel_path).parts
 
@@ -30,10 +32,10 @@ def _safe_manifest_path(rel_path: str) -> bool:
 def _resolve_manifest_artifact_path(repo_root: Path, rel_path: str) -> Path | None:
     if not _safe_manifest_path(rel_path):
         return None
-    target = (repo_root / rel_path).resolve()
     try:
+        target = (repo_root / rel_path).resolve()
         target.relative_to(repo_root)
-    except ValueError:
+    except (OSError, RuntimeError, ValueError):
         return None
     return target
 

--- a/src/hermes_katana/runtime_artifacts.py
+++ b/src/hermes_katana/runtime_artifacts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Any
 
 from hermes_katana.installer.compat_snapshots import (
@@ -20,10 +21,28 @@ def runtime_artifact_manifest_path() -> Path:
     return _DEFAULT_MANIFEST
 
 
+def _safe_manifest_path(rel_path: str) -> bool:
+    if not rel_path or rel_path.startswith("/") or "\\" in rel_path:
+        return False
+    return ".." not in PurePosixPath(rel_path).parts
+
+
+def _resolve_manifest_artifact_path(repo_root: Path, rel_path: str) -> Path | None:
+    if not _safe_manifest_path(rel_path):
+        return None
+    target = (repo_root / rel_path).resolve()
+    try:
+        target.relative_to(repo_root)
+    except ValueError:
+        return None
+    return target
+
+
 def verify_runtime_artifact_manifest(
     manifest_path: str | Path | None = None,
 ) -> dict[str, Any]:
     """Verify the runtime artifact manifest against the local checkout."""
+    repo_root = _REPO_ROOT.resolve()
     manifest_file = Path(manifest_path or _DEFAULT_MANIFEST).expanduser().resolve()
     if not manifest_file.exists():
         return {
@@ -83,7 +102,11 @@ def verify_runtime_artifact_manifest(
             errors.append(f"{name}: manifest entry is missing path/kind/sha256")
             continue
 
-        target = (_REPO_ROOT / rel_path).resolve()
+        target = _resolve_manifest_artifact_path(repo_root, rel_path)
+        if target is None:
+            errors.append(f"{name}: unsafe artifact path {rel_path!r}")
+            continue
+
         if not target.exists():
             missing.append(f"{name}: missing {rel_path}")
             continue

--- a/tests/unit/test_runtime_artifacts.py
+++ b/tests/unit/test_runtime_artifacts.py
@@ -76,6 +76,20 @@ def test_verify_runtime_artifact_manifest_flags_empty_required_directory(tmp_pat
     assert result["empty"] == ["empty_dir: directory is empty at empty"]
 
 
+def _write_single_artifact_manifest(repo_root, rel_path: str) -> None:
+    manifest = {
+        "version": 1,
+        "artifacts": {
+            "escape": {
+                "kind": "file",
+                "path": rel_path,
+                "sha256": "0" * 64,
+            }
+        },
+    }
+    (repo_root / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
 def test_verify_runtime_artifact_manifest_rejects_parent_traversal(tmp_path, monkeypatch):
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
@@ -102,6 +116,21 @@ def test_verify_runtime_artifact_manifest_rejects_parent_traversal(tmp_path, mon
     assert result["ready"] is False
     assert result["verified"] == 0
     assert result["errors"] == ["escape: unsafe artifact path '../outside.bin'"]
+
+
+def test_verify_runtime_artifact_manifest_rejects_absolute_backslash_drive_and_nul_paths(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    monkeypatch.setattr(runtime_artifacts_mod, "_REPO_ROOT", repo_root)
+
+    for rel_path in ("/etc/passwd", r"models\artifact.bin", "C:/Users/example/artifact.bin", "safe\x00name.bin"):
+        _write_single_artifact_manifest(repo_root, rel_path)
+
+        result = runtime_artifacts_mod.verify_runtime_artifact_manifest(repo_root / "manifest.json")
+
+        assert result["ready"] is False
+        assert result["verified"] == 0
+        assert result["errors"] == [f"escape: unsafe artifact path {rel_path!r}"]
 
 
 def test_verify_runtime_artifact_manifest_rejects_symlink_escape(tmp_path, monkeypatch):

--- a/tests/unit/test_runtime_artifacts.py
+++ b/tests/unit/test_runtime_artifacts.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from hermes_katana import runtime_artifacts as runtime_artifacts_mod
 
 
@@ -72,3 +74,64 @@ def test_verify_runtime_artifact_manifest_flags_empty_required_directory(tmp_pat
     assert result["ready"] is False
     assert result["verified"] == 0
     assert result["empty"] == ["empty_dir: directory is empty at empty"]
+
+
+def test_verify_runtime_artifact_manifest_rejects_parent_traversal(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outside_file = tmp_path / "outside.bin"
+    outside_file.write_bytes(b"outside")
+
+    monkeypatch.setattr(runtime_artifacts_mod, "_REPO_ROOT", repo_root)
+
+    manifest = {
+        "version": 1,
+        "artifacts": {
+            "escape": {
+                "kind": "file",
+                "path": "../outside.bin",
+                "sha256": runtime_artifacts_mod.compute_file_sha256(outside_file),
+            }
+        },
+    }
+    manifest_path = repo_root / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = runtime_artifacts_mod.verify_runtime_artifact_manifest(manifest_path)
+
+    assert result["ready"] is False
+    assert result["verified"] == 0
+    assert result["errors"] == ["escape: unsafe artifact path '../outside.bin'"]
+
+
+def test_verify_runtime_artifact_manifest_rejects_symlink_escape(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outside_file = tmp_path / "outside.bin"
+    outside_file.write_bytes(b"outside")
+    symlink_path = repo_root / "artifact-link.bin"
+    try:
+        symlink_path.symlink_to(outside_file)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+
+    monkeypatch.setattr(runtime_artifacts_mod, "_REPO_ROOT", repo_root)
+
+    manifest = {
+        "version": 1,
+        "artifacts": {
+            "escape": {
+                "kind": "file",
+                "path": "artifact-link.bin",
+                "sha256": runtime_artifacts_mod.compute_file_sha256(outside_file),
+            }
+        },
+    }
+    manifest_path = repo_root / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = runtime_artifacts_mod.verify_runtime_artifact_manifest(manifest_path)
+
+    assert result["ready"] is False
+    assert result["verified"] == 0
+    assert result["errors"] == ["escape: unsafe artifact path 'artifact-link.bin'"]


### PR DESCRIPTION
## Summary
- reject runtime artifact manifest paths containing traversal, absolute paths, or backslashes
- verify resolved artifact targets remain under the checkout root, including symlink targets
- add regression tests for parent traversal and symlink escapes

## Verification
- .venv/bin/python -m pytest tests/unit/test_runtime_artifacts.py -q --tb=short
- .venv/bin/python -m ruff check src/hermes_katana/runtime_artifacts.py tests/unit/test_runtime_artifacts.py