### PR TITLE
docs(README): v3.1 release refresh — Research & Models + v17 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - v3.1 preprint under `paper/` (*Cross-Platform Transferability of Prompt Injection Attacks: Universal Attack Surfaces and an Origin-Aware Defense*), self-contained (LaTeX source, figures, and bibliography), buildable with `pdflatex`/`bibtex` via the included Makefile.
 - Released the v17 origin-aware prompt-injection classifiers on Hugging Face under MIT: `Carlosian/hermes-katana-17` (DeBERTa-v3-large teacher) and `Carlosian/hermes-katana-90` (distilled MiniLM-L6 CPU scanner).
+- Registered those models in the artifact CLI: `katana artifacts download v17_large` / `v17_minilm` (commit-pinned, integrity-verified via `artifact_manifest.json`; kept out of the managed `setup --all` as research models).
 - GitHub Pages static manual at `docs/index.html`.
 - Generated policy documentation check via `scripts/generate_policy_assets.py`.
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,8 @@ Run it with `katana proving-ground run|batch|synthesize`; see
 ### Trained classifiers
 
 The scanner cascade can route content to purpose-trained models instead of
-relying on patterns alone. The v3.1 origin-aware classifiers are published on
+relying on patterns alone. The v3.1 origin-aware classifiers (the internal "v17"
+label is the training-data iteration behind this release) are published on
 Hugging Face under MIT:
 
 | Model | Role | Headline metric | Hugging Face |

--- a/README.md
+++ b/README.md
@@ -259,15 +259,22 @@ Hugging Face under MIT:
 | Model | Role | Headline metric | Hugging Face |
 |-------|------|-----------------|--------------|
 | **DeBERTa-v3-large** | 9-class origin-aware classifier (high accuracy) | Macro F1 **0.938**, 0.48% FPR (confirmed-only benchmark) | `Carlosian/hermes-katana-17` |
-| **MiniLM-L6 (distilled)** | Default CPU scanner (~90 MB) | Macro F1 **0.931**, 0.00% benchmark FPR | `Carlosian/hermes-katana-90` |
+| **MiniLM-L6 (distilled)** | Distilled CPU model (~90 MB) | Macro F1 **0.931**, 0.00% benchmark FPR | `Carlosian/hermes-katana-90` |
 | **Behavioral-signature scanner** | Telemetry-only attack detection | AUC **0.847** (no semantic analysis) | bundled |
 
-The distilled MiniLM-L6 (~90 MB) runs on CPU and is the default scanner;
-DeBERTa-v3-large is the higher-accuracy model held in reserve. Both ingest a
-declared origin tier; a token ablation shows the larger model is content-driven
-(invariant to the tag) while the distilled scanner responds to declared
-provenance. The behavioral-signature scanner is a lightweight model over 33
-runtime-telemetry features and flags attacks without reading content at all.
+These are the models evaluated in the paper, published for download and
+reproduction. Both ingest a declared origin tier; a token ablation shows
+DeBERTa-v3-large is content-driven (invariant to the tag) while the distilled
+MiniLM responds to declared provenance. The behavioral-signature scanner is a
+lightweight model over 33 runtime-telemetry features and flags attacks without
+reading content at all.
+
+For production scanning the toolkit installs a distilled MiniLM **ONNX** artifact
+by default (CPU, no PyTorch) via `katana artifacts download minilm`; see
+[`docs/artifacts.md`](docs/artifacts.md) for the runtime artifact registry and
+its `minilm` / `minilm_torch` / `large` selectors. (The v17 research models above
+are published on Hugging Face for reproduction and are not yet wired into that
+registry.)
 
 ### Datasets
 
@@ -308,7 +315,7 @@ katana audit show|verify|stats|clear
 katana proxy start|stop|status
 
 katana artifacts status [--all]      Show ML model artifact status
-katana artifacts download SELECTOR   Download a model artifact (minilm/large)
+katana artifacts download SELECTOR   Download a model artifact (minilm, minilm_torch, large)
 katana artifacts path                Show artifact cache path
 
 katana benchmark                     Run benchmark suites

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ open-source project, cite the project and the research it builds on:
   title   = {Hermes Katana: Defense-in-Depth Security for AI Agents},
   author  = {{Hermes Katana contributors}},
   year    = {2026},
-  version = {3.0.0},
+  version = {3.1.0},
   url     = {https://github.com/claudlos/hermes-katana},
   note    = {Open-source agent security middleware, scanner suite, policy engine, vault, audit trail, and proving-ground harness}
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-## Hermes Katana
+## Overview
 
 Hermes Katana is a defense-in-depth security layer for AI agents. It tracks
 where text came from, scans decoded content for prompt injection and unsafe
@@ -26,16 +26,15 @@ and records decisions in a tamper-evident audit trail.
 
 The user manual and command map are published at
 [claudlos.github.io/hermes-katana](https://claudlos.github.io/hermes-katana/).
-The checked-in manual source lives at [`docs/index.html`](docs/index.html), and
-release-thread captions for the twelve infographic cards are in
-[`docs/v3_release_thread.md`](docs/v3_release_thread.md).
 
 Feature highlights:
 
 - Character-level provenance inspired by [Google DeepMind's CaMeL paper](https://arxiv.org/abs/2503.18813)
 - Runtime policy decisions for clean, tainted, dangerous, and unknown tool calls
+- Configurable human-in-the-loop escalation for tool calls that need approval
+- Purpose-trained injection classifiers — a distilled MiniLM by default, DeBERTa-v3-large for high accuracy
+- Proving Ground harness for empirical, multi-model attack-effectiveness testing
 - Explicit false-positive and adversarial regression gates
-- Optional proving-ground harness for empirical attack-effectiveness testing
 
 ---
 
@@ -67,11 +66,12 @@ See [`docs/artifacts.md`](docs/artifacts.md) for artifact setup and verification
 See [docs/quickstart.md](docs/quickstart.md) for the full setup guide and
 [docs/runbook.md](docs/runbook.md) for day-2 operations.
 
+---
 
 ## Architecture
 
 ```
-                        HermesKatana — 7-Layer Defense Model
+                        Hermes Katana — 7-Layer Defense Model
 
     ┌───────────────────────────────────────────────────────────────┐
     │                     Agent Runtime (Hermes)                    │
@@ -171,6 +171,14 @@ Declarative rules evaluated on every tool call. Three built-in presets:
 | `permissive` | LOG_ONLY | LOG_ONLY | DENY | LOG_ONLY | LOG_ONLY |
 <!-- policy-table:end -->
 
+**Human-in-the-loop.** When a decision resolves to `ESCALATE`, the
+`escalate_action` setting decides what happens next: `block` (default,
+fail-closed — correct for headless CLI/gateway runs), `acp_prompt` (ask the human
+through the agent's interactive approval prompt, e.g. in Zed/ACP editor
+sessions), or `auto_approve` (allow with a loud warning; trusted automation
+only). It falls back to `block` whenever no interactive approver is available, so
+unattended runs never silently allow.
+
 Custom YAML policies with hot-reload:
 
 ```yaml
@@ -202,6 +210,76 @@ mitmproxy-based interceptor that strips vault secrets from all outbound request 
 
 ---
 
+## Research & Models
+
+Hermes Katana v3 is backed by an empirical research program — a multi-model
+attack harness, purpose-trained injection classifiers, and a diverse,
+adversarially-validated dataset. This data-and-model work is the core of the v3
+release. The methodology and full results are written up in the companion paper,
+*Cross-Platform Transferability of Prompt Injection Attacks: Universal Attack
+Surfaces and an Origin-Aware Defense*, released alongside v3.1.
+
+### Proving Ground
+
+The Proving Ground is a sharded, resumable adversarial battery. It samples
+candidate prompt-injection attacks, replays them against real models in seeded
+sandbox workspaces, and admits only those that produce measurable behavioral
+drift across multiple targets. Every session captures per-turn runtime telemetry
+(latency, token throughput, logprob entropy), tool-call sequences, and workspace
+snapshots.
+
+Scale and headline findings from the v3 evaluation battery:
+
+- **2,363** agent-harness and API-backend sessions across **16 model/harness
+  combinations on 5 platforms**, drawn from a stratified pool of **17,643**
+  attacks, plus a separate multilingual battery over **11 languages** on three
+  models.
+- **Harness design shapes outcomes — but does not dominate model alignment.** In
+  a preregistered matched-pair test on a fixed model (Claude Haiku 4.5), the
+  permission-gated Claude Code CLI was *more* vulnerable than a flat agent
+  harness (40.8% vs 10.2%, +30.65 pp, p < 1e-6), rejecting the intuition that a
+  gated harness is inherently safer.
+- **Vulnerability is scale-dependent but not scale-eliminated:** small local
+  models (~4B) showed **48–95%** attack effectiveness; frontier models **8–10%**.
+- **Robustness is not language-invariant:** across 11 languages, mean
+  effectiveness ranged from **12% to 39%** depending on the model, and which
+  language is most exploitable does not transfer across model families.
+- With Katana scanning in front, effective attacks dropped from **12.40% to
+  0.00%** (paired n=10,774; McNemar p≈0).
+
+Run it with `katana proving-ground run|batch|synthesize`; see
+[docs/proving_ground/](docs/proving_ground/) for harness notes.
+
+### Trained classifiers
+
+The scanner cascade can route content to purpose-trained models instead of
+relying on patterns alone. The v3.1 origin-aware classifiers are published on
+Hugging Face under MIT:
+
+| Model | Role | Headline metric | Hugging Face |
+|-------|------|-----------------|--------------|
+| **DeBERTa-v3-large** | 9-class origin-aware classifier (high accuracy) | Macro F1 **0.938**, 0.48% FPR (confirmed-only benchmark) | `Carlosian/hermes-katana-17` |
+| **MiniLM-L6 (distilled)** | Default CPU scanner (~90 MB) | Macro F1 **0.931**, 0.00% benchmark FPR | `Carlosian/hermes-katana-90` |
+| **Behavioral-signature scanner** | Telemetry-only attack detection | AUC **0.847** (no semantic analysis) | bundled |
+
+The distilled MiniLM-L6 (~90 MB) runs on CPU and is the default scanner;
+DeBERTa-v3-large is the higher-accuracy model held in reserve. Both ingest a
+declared origin tier; a token ablation shows the larger model is content-driven
+(invariant to the tag) while the distilled scanner responds to declared
+provenance. The behavioral-signature scanner is a lightweight model over 33
+runtime-telemetry features and flags attacks without reading content at all.
+
+### Datasets
+
+Training and evaluation use a tiered, adversarially-validated corpus: a *gold*
+set of confirmed attacks (effective across ≥3 model families), a *silver* set of
+synthetic and teacher/critic-accepted attacks, matched *benign* controls, and
+*hard negatives* for false-positive pressure — with multilingual and encoded
+attacks represented in every split. This diverse-data generation and validation
+pipeline is the central innovation of v3.
+
+---
+
 ## CLI Reference
 
 ```
@@ -229,6 +307,10 @@ katana audit show|verify|stats|clear
 
 katana proxy start|stop|status
 
+katana artifacts status [--all]      Show ML model artifact status
+katana artifacts download SELECTOR   Download a model artifact (minilm/large)
+katana artifacts path                Show artifact cache path
+
 katana benchmark                     Run benchmark suites
 katana proving-ground ...            Run the empirical attack harness
 katana version                       Print version
@@ -238,7 +320,7 @@ katana version                       Print version
 
 ## Comparison
 
-| Feature | HermesKatana | Invariant | NeMo Guardrails | LLM Guard | Lakera Guard |
+| Feature | Hermes Katana | Invariant | NeMo Guardrails | LLM Guard | Lakera Guard |
 |---------|:---:|:---:|:---:|:---:|:---:|
 | CaMeL taint tracking | ✅ | — | — | — | — |
 | Character-level taint | ✅ | — | — | — | — |
@@ -382,7 +464,7 @@ patterns from a broader security ecosystem:
 - **[NVIDIA NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails)** — Inspiration for the declarative policy DSL approach and conversation-level rail concepts.
 - **[LLM Guard by Protect AI](https://github.com/protectai/llm-guard)** — Inspiration for modular scanner architecture and the input/output scanning pattern.
 - **[Invariant Labs](https://github.com/invariantlabs-ai/invariant)** — Inspiration for policy-as-code agent security and trace-level analysis concepts.
-- **[mitmproxy](https://mitmproxy.org/)** — The excellent HTTPS proxy that powers HermesKatana's network interception layer.
+- **[mitmproxy](https://mitmproxy.org/)** — The excellent HTTPS proxy that powers Hermes Katana's network interception layer.
 
 Mentioning these projects does not imply endorsement or affiliation.
 

--- a/README.md
+++ b/README.md
@@ -272,9 +272,10 @@ reading content at all.
 For production scanning the toolkit installs a distilled MiniLM **ONNX** artifact
 by default (CPU, no PyTorch) via `katana artifacts download minilm`; see
 [`docs/artifacts.md`](docs/artifacts.md) for the runtime artifact registry and
-its `minilm` / `minilm_torch` / `large` selectors. (The v17 research models above
-are published on Hugging Face for reproduction and are not yet wired into that
-registry.)
+its `minilm` / `minilm_torch` / `large` selectors. The v17 research models above
+are also registered for explicit download (`katana artifacts download v17_minilm`
+/ `v17_large`) — pinned by commit and integrity-verified — but kept out of the
+default `setup --all`.
 
 ### Datasets
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -23,6 +23,10 @@ for local high-accuracy experiments and is never selected by default.
 | `minilm`, `small` | `katana_v15_distill_minilm_onnx` | `Carlosian/hermes-katana-v15-distill-minilm-onnx` | yes |
 | `minilm_torch`, `small_torch` | `katana_v15_distill_minilm_torch` | `Carlosian/hermes-katana-v15-distill-minilm` | no |
 | `large`, `v15_large` | `katana_v15_large` | `Carlosian/hermes-katana-v15-large` | no |
+| `v17_large`, `deberta_v17` | `katana_v17_large` | `Carlosian/hermes-katana-17` | no (research) |
+| `v17_minilm`, `small_v17` | `katana_v17_minilm` | `Carlosian/hermes-katana-90` | no (research) |
+
+The `v17_*` rows are the v3.1 paper's origin-aware classifiers (`Carlosian/hermes-katana-17` and `-90`). They are pinned by commit revision, carry an `artifact_manifest.json`, and are treated as research models: downloadable explicitly (e.g. `katana artifacts download v17_minilm`) but excluded from managed `setup --all` / `full`.
 
 Each Hugging Face repo must include an `artifact_manifest.json`. Katana treats the manifest as part of the artifact and
 refuses to mark the artifact ready when required files are missing, hashes do not match, sizes do not match, or the

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,7 +38,7 @@ katana setup
 **Expected output:**
 
 ```
-Successfully installed hermes-katana-3.0.0
+Successfully installed hermes-katana-3.1.0
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hermes-katana"
-version = "3.0.0"
+version = "3.1.0"
 description = "Defense-in-depth security toolkit for LLM agents — taint tracking, proxy secret guard, policy engine, and red-team benchmarking"
 authors = [{name = "Hermes Katana contributors"}]
 requires-python = ">=3.10"

--- a/src/hermes_katana/_version.py
+++ b/src/hermes_katana/_version.py
@@ -2,5 +2,5 @@
 
 from __future__ import annotations
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 ARTIFACT_REVISION = f"v{__version__}"

--- a/src/hermes_katana/artifacts.py
+++ b/src/hermes_katana/artifacts.py
@@ -25,6 +25,9 @@ DEFAULT_MINILM_ONNX_REPO = "Carlosian/hermes-katana-v15-distill-minilm-onnx"
 DEFAULT_MINILM_TORCH_REPO = "Carlosian/hermes-katana-v15-distill-minilm"
 DEFAULT_V15_LARGE_REPO = "Carlosian/hermes-katana-v15-large"
 DEFAULT_REVISION = ARTIFACT_REVISION
+# v15 runtime artifacts are pinned to their own HF revision, decoupled from the
+# package version so a package version bump never retargets their download.
+V15_REVISION = "v3.0.0"
 ARTIFACT_MANIFEST = "artifact_manifest.json"
 
 MINILM_ONNX_REQUIRED_FILES = (
@@ -158,7 +161,7 @@ _BASE_ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
         display_name="Katana v15 MiniLM ONNX",
         repo_id=DEFAULT_MINILM_ONNX_REPO,
         repo_type="model",
-        revision=DEFAULT_REVISION,
+        revision=V15_REVISION,
         required_files=MINILM_ONNX_REQUIRED_FILES,
         allow_patterns=MINILM_ONNX_ALLOW_PATTERNS,
         size_label="~88 MB",
@@ -182,7 +185,7 @@ _BASE_ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
         display_name="Katana v15 MiniLM PyTorch",
         repo_id=DEFAULT_MINILM_TORCH_REPO,
         repo_type="model",
-        revision=DEFAULT_REVISION,
+        revision=V15_REVISION,
         required_files=MINILM_TORCH_REQUIRED_FILES,
         allow_patterns=MINILM_TORCH_ALLOW_PATTERNS,
         size_label="~88 MB",
@@ -200,7 +203,7 @@ _BASE_ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
         display_name="Katana v15 Large",
         repo_id=DEFAULT_V15_LARGE_REPO,
         repo_type="model",
-        revision=DEFAULT_REVISION,
+        revision=V15_REVISION,
         required_files=V15_LARGE_REQUIRED_FILES,
         allow_patterns=V15_LARGE_ALLOW_PATTERNS,
         size_label="large",

--- a/src/hermes_katana/artifacts.py
+++ b/src/hermes_katana/artifacts.py
@@ -65,6 +65,39 @@ V15_LARGE_REQUIRED_FILES = (
 
 V15_LARGE_ALLOW_PATTERNS = (*V15_LARGE_REQUIRED_FILES, "README.md")
 
+# v3.1 origin-aware research models (paper artifacts). Pinned to the commit that
+# carries the integrity manifest so downloads are reproducible.
+DEFAULT_V17_LARGE_REPO = "Carlosian/hermes-katana-17"
+DEFAULT_V17_MINILM_REPO = "Carlosian/hermes-katana-90"
+V17_LARGE_REVISION = "a08883466abd2924587ac0646fa693c0a27b50af"
+V17_MINILM_REVISION = "fc52b343e206d190bcb773a32a909a3885fdf480"
+
+V17_LARGE_REQUIRED_FILES = (
+    "model.safetensors",
+    "config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "spm.model",
+    ARTIFACT_MANIFEST,
+)
+
+V17_LARGE_ALLOW_PATTERNS = (*V17_LARGE_REQUIRED_FILES, "README.md", "results_comparison.png")
+
+V17_MINILM_REQUIRED_FILES = (
+    "model.safetensors",
+    "config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "vocab.txt",
+    ARTIFACT_MANIFEST,
+)
+
+V17_MINILM_ALLOW_PATTERNS = (*V17_MINILM_REQUIRED_FILES, "README.md", "results_comparison.png")
+
 
 class ArtifactError(RuntimeError):
     """Base artifact error."""
@@ -100,6 +133,7 @@ class ArtifactSpec:
     revision_env_var: str | None = None
     interactive_default: bool = False
     requires_confirmation: bool = False
+    managed_setup: bool = True
 
 
 @dataclass(frozen=True)
@@ -178,6 +212,44 @@ _BASE_ARTIFACT_SPECS: tuple[ArtifactSpec, ...] = (
         interactive_default=False,
         requires_confirmation=True,
     ),
+    ArtifactSpec(
+        name="katana_v17_large",
+        aliases=("v17_large", "large_v17", "deberta_v17", "katana_v17", "katana_v17_large"),
+        display_name="Katana v17 DeBERTa-v3-large (origin-aware)",
+        repo_id=DEFAULT_V17_LARGE_REPO,
+        repo_type="model",
+        revision=V17_LARGE_REVISION,
+        required_files=V17_LARGE_REQUIRED_FILES,
+        allow_patterns=V17_LARGE_ALLOW_PATTERNS,
+        size_label="~1.7 GB",
+        role="v3.1 origin-aware 9-class classifier (high accuracy)",
+        profile="max_local",
+        path_env_var="KATANA_V17_LARGE_DIR",
+        repo_env_var="KATANA_V17_LARGE_HF_REPO_ID",
+        revision_env_var="KATANA_V17_LARGE_HF_REVISION",
+        interactive_default=False,
+        requires_confirmation=True,
+        managed_setup=False,
+    ),
+    ArtifactSpec(
+        name="katana_v17_minilm",
+        aliases=("v17_minilm", "minilm_v17", "small_v17", "katana_v17_minilm", "katana_v17_distill_minilm"),
+        display_name="Katana v17 MiniLM-L6 (origin-aware, distilled)",
+        repo_id=DEFAULT_V17_MINILM_REPO,
+        repo_type="model",
+        revision=V17_MINILM_REVISION,
+        required_files=V17_MINILM_REQUIRED_FILES,
+        allow_patterns=V17_MINILM_ALLOW_PATTERNS,
+        size_label="~90 MB",
+        role="v3.1 origin-aware distilled CPU classifier (PyTorch)",
+        profile="torch_cpu",
+        path_env_var="KATANA_V17_MINILM_DIR",
+        repo_env_var="KATANA_V17_MINILM_HF_REPO_ID",
+        revision_env_var="KATANA_V17_MINILM_HF_REVISION",
+        interactive_default=False,
+        requires_confirmation=False,
+        managed_setup=False,
+    ),
 )
 
 
@@ -238,6 +310,16 @@ def minilm_torch_spec(repo_id: str | None = None, revision: str | None = None) -
 def v15_large_spec(repo_id: str | None = None, revision: str | None = None) -> ArtifactSpec:
     """Build the optional large v15 artifact spec with env overrides."""
     return artifact_spec("large", repo_id=repo_id, revision=revision)
+
+
+def v17_large_spec(repo_id: str | None = None, revision: str | None = None) -> ArtifactSpec:
+    """Build the v3.1 origin-aware DeBERTa-v3-large artifact spec with env overrides."""
+    return artifact_spec("v17_large", repo_id=repo_id, revision=revision)
+
+
+def v17_minilm_spec(repo_id: str | None = None, revision: str | None = None) -> ArtifactSpec:
+    """Build the v3.1 origin-aware distilled MiniLM artifact spec with env overrides."""
+    return artifact_spec("v17_minilm", repo_id=repo_id, revision=revision)
 
 
 def artifact_path(spec: ArtifactSpec, target_dir: str | Path | None = None) -> Path:

--- a/src/hermes_katana/cli/main.py
+++ b/src/hermes_katana/cli/main.py
@@ -346,7 +346,7 @@ def _run_artifacts_setup(
     selected = []
 
     if all_models:
-        selected = list(specs)
+        selected = [spec for spec in specs if spec.managed_setup]
     elif small or small_torch or large:
         if small:
             selected.append(by_alias["minilm"])
@@ -366,6 +366,8 @@ def _run_artifacts_setup(
     else:
         console.print("[bold]Katana artifact setup[/bold]\n")
         for spec in specs:
+            if not spec.managed_setup:
+                continue
             if no_large and spec.requires_confirmation:
                 continue
             status = artifact_status(spec)
@@ -415,7 +417,7 @@ def _verify_full_setup(*, target_dir: str | None) -> None:
     importlib.invalidate_caches()
     failures: list[str] = []
 
-    specs = artifact_specs()
+    specs = [spec for spec in artifact_specs() if spec.managed_setup]
     target_root = Path(target_dir).expanduser().resolve() if target_dir else None
     multiple = len(specs) > 1
     for spec in specs:

--- a/src/hermes_katana/proving_ground/scripts/batch_run.py
+++ b/src/hermes_katana/proving_ground/scripts/batch_run.py
@@ -2,7 +2,7 @@
 
 Why this exists: the existing `run_shard.py` and `run_agent_shard.py` workers do
 live HTTPS calls per attack. At 20-60s/attack they can't practically clear the
-215K-row multilingual corpus or the 18-model × 11-language scale. Batch APIs
+215K-row multilingual corpus or the 16 model/harness × 11-language scale. Batch APIs
 cut cost ~50% and lift throughput by ~10x by letting the provider queue our
 requests and fulfil them within 24h.
 

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -77,6 +77,22 @@ def test_registry_lists_small_and_large_models():
     assert artifact_spec("large").name == "katana_v15_large"
 
 
+def test_registry_includes_v17_research_models():
+    specs = {spec.name: spec for spec in artifact_specs()}
+    assert "katana_v17_large" in specs
+    assert "katana_v17_minilm" in specs
+    assert artifact_spec("v17_large").repo_id == "Carlosian/hermes-katana-17"
+    assert artifact_spec("v17_minilm").repo_id == "Carlosian/hermes-katana-90"
+    # research models are explicit-download-only (excluded from managed setup --all/full)
+    assert specs["katana_v17_large"].managed_setup is False
+    assert specs["katana_v17_minilm"].managed_setup is False
+    # pinned to a commit revision and integrity-verified via the manifest
+    assert specs["katana_v17_minilm"].revision
+    assert ARTIFACT_MANIFEST in specs["katana_v17_minilm"].required_files
+    # v15 aliases are unchanged
+    assert artifact_spec("minilm").name == "katana_v15_distill_minilm_onnx"
+
+
 def test_unknown_registry_model_fails_closed():
     with pytest.raises(UnknownArtifactError):
         artifact_spec("mystery-model")

--- a/tests/unit/test_hermes_plugin.py
+++ b/tests/unit/test_hermes_plugin.py
@@ -171,7 +171,7 @@ class TestPluginSetup:
 
     def test_plugin_metadata(self):
         assert hermes_plugin.plugin_name == "katana"
-        assert hermes_plugin.plugin_version == "3.0.0"
+        assert hermes_plugin.plugin_version == "3.1.0"
 
     def test_setup_creates_middleware_chain(self):
         ctx = MockPluginContext(config={"audit_enabled": False})


### PR DESCRIPTION
## v3.1 README refresh

Completes the in-progress README edit and brings the **Research & Models** section in line with the finalized v3.1 paper and the released v17 models.

- **Corrected stale numbers** (the WIP edit carried pre-rebase values): 2,919→**2,363** sessions, 18→**16** combinations; small-model effectiveness 90–100%→**48–95%**; the harness finding now states the *preregistered* result (Claude Code CLI **40.8% vs** Hermes **10.2%**, +30.65 pp — gated harness was *more* vulnerable, not less); multilingual 7–14%→**12–39%**; DeBERTa macro F1 ≈0.92→**0.938**.
- **Model table → the released v17 models** (`Carlosian/hermes-katana-17`, `-90`) with their real metrics, replacing the old `v15-*` references.
- **Correct paper title** (*Universal Attack Surfaces and an Origin-Aware Defense*).
- Keeps the structural improvements (Overview, human-in-the-loop note, `katana artifacts` CLI, "Hermes Katana" spacing).

After this merges, I'll cut the **v3.1 GitHub release** (tag the merge commit + release notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added v17 origin-aware research model variants (v17_large, v17_minilm) available via artifact CLI for explicit download.
  * New Human-in-the-loop handling and Research & Models documentation sections.

* **Documentation**
  * Updated documentation to reflect v3.1.0 release with new features, model information, and extended CLI commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->