### PR TITLE
fix(security): clear all 46 code-scanning alerts (Trivy openssl + zizmor artipacked)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Effective build-context ignore file.
+#
+# The proving-ground image is built with the repository root as the build
+# context (docker build -f docker/proving-ground/Dockerfile . — see
+# .github/workflows/security.yml). Docker only honors the .dockerignore at the
+# context root, so these rules — mirrored from docker/proving-ground/.dockerignore
+# — are the ones that actually take effect. Keep the two in sync.
+#
+# Never send secrets/runtime data to the Docker build context.
+.env
+.env.*
+auth.json
+*.db
+*.sqlite
+*.sqlite3
+*.log
+results/
+sessions/
+batch/
+shards/
+synthdata/incoming/
+synthdata/checkpoints/
+.venv/
+__pycache__/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.git/

--- a/.github/workflows/hermes-drift.yml
+++ b/.github/workflows/hermes-drift.yml
@@ -15,9 +15,10 @@ concurrency:
   group: hermes-drift-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: the elevated write scopes are granted only to the drift job
+# that needs them (snapshot-refresh push + maintenance PR), not workflow-wide.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
@@ -28,8 +29,13 @@ jobs:
     name: Patches apply to latest Hermes
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
@@ -44,6 +50,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
+          # Checkout no longer persists credentials (persist-credentials: false),
+          # so wire the workflow token into git for the snapshot-refresh push.
+          gh auth setup-git
           python scripts/hermes_drift_autorepair.py \
             --checkout "${RUNNER_TEMP}/hermes-agent" \
             --default-branch "${DEFAULT_BRANCH}" \

--- a/docker/proving-ground/Dockerfile
+++ b/docker/proving-ground/Dockerfile
@@ -3,7 +3,7 @@
 # Public-safe variant: this image does NOT bake auth.json, .env files, corpora,
 # sessions, or results. Mount runtime credentials/config explicitly.
 
-FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203 AS base
+FROM python:3.12-slim@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9 AS base
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \


### PR DESCRIPTION
Resolves all **46 open code-scanning alerts** at the source.

## What was failing
| Count | Tool | Issue | Root cause |
|---|---|---|---|
| 45 | Trivy | `OsPackageVulnerability` — 15 openssl CVEs (incl. **HIGH `CVE-2026-45447`**) × 3 binary packages (`openssl`, `libssl3t64`, `openssl-provider-legacy`) | The pinned `python:3.12-slim` base digest shipped the openssl family at `3.5.6-1~deb13u1`; a digest pin never receives Debian's patch. |
| 1 | zizmor | `artipacked` — `hermes-drift.yml` checkout persisted credentials | It was the only `actions/checkout` in the repo missing `persist-credentials: false`. |

## Fixes
**1. `docker/proving-ground/Dockerfile` — base-image digest bump**
`@sha256:090ba77e…` → `@sha256:d764629c…`. The new digest is the same `python:3.12` on Debian 13 (trixie) but ships the openssl family at **`3.5.6-1~deb13u2`** — the fixed version for all 15 CVEs. Chosen over an in-Dockerfile `apt-get upgrade`, which would trip **hadolint DL3005** in the `docker-hygiene` CI job.

**2. `.github/workflows/hermes-drift.yml` — `persist-credentials: false` + push auth**
Adds the `artipacked` remediation. Because this job auto-refreshes a snapshot PR (`git push --force-with-lease` in `scripts/hermes_drift_autorepair.py`), it also adds `gh auth setup-git` so the push still authenticates via `GH_TOKEN` once the checkout no longer persists credentials. The elevated `contents: write` / `pull-requests: write` scopes are moved from workflow-level to the `drift` job (least privilege).

**3. Root `.dockerignore` (hardening)**
`docker/proving-ground/.dockerignore` was inert — Docker only reads the `.dockerignore` at the build-context root, and CI builds with the repo root as context. Mirrors the secret/runtime-data denylist where it actually takes effect. (Image contents were already safe — the Dockerfile uses narrow explicit `COPY`s, never `COPY . /app`.)

## Verification
- Built the proving-ground image from **both** digests and scanned with Trivy 0.71.0 under the exact CI filter (`severity HIGH,CRITICAL; ignore-unfixed; os,library`): **old → 45 rows reproduced, new → 0**.
- Confirmed the new image is still Python 3.12.13 / Debian 13; `pip install -e .[proving-ground,hf]` succeeds; only the 3 openssl packages change (u1→u2), no other package churn; no new fixed-version HIGH/CRITICAL introduced.
- `hadolint` runs clean on the changed Dockerfile.
- Verified the `gh auth setup-git` + `GH_TOKEN` credential-helper mechanism authenticates the auto-PR `git push` (new-branch and update paths) without `gh auth login`.

## Auto-close
All 45 Trivy alerts are `category=trivy-image` and the zizmor alert is `category=zizmor`, both on `refs/heads/master`. On merge, the `security.yml` `container-image` (Trivy) and `workflow-hardening` (zizmor) jobs re-scan master under those same categories and report nothing, so GitHub auto-resolves all 46. No manual dismissal expected.

## Optional follow-ups (out of scope; not among the alerts)
- `release-gate.yml` secret-scan grants `security-events: write` on fork PRs without the fork-PR `if:` guard used in `security.yml`.
- Consider a *gating* Trivy step (`exit-code: '1'`) on the built image so a future regressed base digest fails CI rather than only filing an alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)