### PR TITLE
policy(balanced): allow clean clarify / skill_manage / vision_analyze

### DIFF
--- a/policies/balanced.yaml
+++ b/policies/balanced.yaml
@@ -382,6 +382,15 @@ policies:
   tags:
   - read-only
   - tainted-read
+- name: balanced_vision_analyze_clean
+  description: Allow clean vision_analyze; tainted reads stay log_only at the higher-priority rule.
+  tool_pattern: vision_analyze
+  conditions: []
+  action: allow
+  priority: 35
+  tags:
+  - read-only
+  - known-tool
 - name: balanced_todo_tainted_log
   description: Log-only for tainted todo access.
   tool_pattern: todo
@@ -507,6 +516,26 @@ policies:
   tags:
   - read-only
   - skills
+  - known-tool
+- name: balanced_clarify_clean
+  description: Always allow clarify; it is the human-in-the-loop question tool and must never be blocked.
+  tool_pattern: clarify
+  conditions: []
+  action: allow
+  priority: 50
+  tags:
+  - read-only
+  - ux
+  - known-tool
+- name: balanced_skill_manage_clean
+  description: Allow clean skill_manage; tainted skill writes stay DENY at the higher-priority rule.
+  tool_pattern: skill_manage
+  conditions: []
+  action: allow
+  priority: 50
+  tags:
+  - skills
+  - side-effect
   - known-tool
 - name: balanced_todo_clean
   description: Allow clean todo updates; tainted todo content is logged by the higher-priority tainted


### PR DESCRIPTION
## Problem
The `balanced` preset's catch-all (`balanced_catchall_clean`, priority 1) escalated every otherwise-unmatched **clean** tool call. With fail-closed escalation and no synchronous approver, this hard-blocked three benign tools:

- **`clarify`** — the human-in-the-loop question tool. Blocking it *deadlocks* the agent: it cannot even ask for approval.
- **`vision_analyze`** — read-only image analysis.
- **`skill_manage`** — procedural-memory writes.

Observed live (Hermes gateway, balanced preset): repeated `escalation_blocked` / `requires approval` on these tools, including the skill auto-curator.

## Fix
Add three priority-50 clean-allow rules (`vision_analyze` at 35, just below its tainted `log_only`@40) so **clean** calls are permitted while **tainted** paths keep their existing higher-priority rules:

| tool | clean (new) | tainted (unchanged) |
|---|---|---|
| `clarify` | allow @50 | — |
| `vision_analyze` | allow @35 | log_only @40 |
| `skill_manage` | allow @50 | **deny @100** |

## Verification
`PolicyEngine.with_defaults("balanced")` → 50 policies load. Clean `clarify`/`vision_analyze`/`skill_manage`/`write_file`/`patch`/`execute_code` → **ALLOW**; an unknown tool still → **ESCALATE** (catch-all safety net intact). Diff is +29/-0 (additive only; no upstream hardening removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the balanced policy preset to enable additional tools and capabilities, including vision analysis, clarification (human-in-the-loop), and skill management features with appropriate safety guardrails based on data integrity conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->