### PR TITLE
[codex] Harden audit follow-up setup paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ The base install is intentionally small and works without model downloads.
 `katana setup` prompts for the small MiniLM ONNX artifact, optional MiniLM
 PyTorch checkpoint, larger PyTorch model, and Proving Ground research harness.
 For unattended installs, use `katana setup --yes` to accept the default small
-ONNX path. Use `katana setup full` to install every setup dependency group,
-download every managed setup model artifact, and verify the result. Research
-artifacts such as `v17_minilm` remain explicit downloads.
+ONNX path and install the separate similarity-softener embedder. Use
+`katana setup full` to install every setup dependency group, download every
+managed setup model artifact, and verify the result. Research artifacts such as
+`v17_minilm` remain explicit downloads.
 
 Large model and dataset artifacts live on Hugging Face, not in this GitHub
 repository. Downloads remain explicit unless you opt into runtime auto-download.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -80,9 +80,10 @@ katana setup full
 ```
 
 This downloads every managed setup model artifact, installs the ONNX Runtime
-CPU, PyTorch CPU, and Proving Ground dependency groups, then verifies that all
-of them are present. Research artifacts such as `v17_minilm` and `v17_large`
-remain explicit downloads.
+CPU, PyTorch CPU, and Proving Ground dependency groups, installs the separate
+similarity-softener embedder, then verifies that all of them are present.
+Research artifacts such as `v17_minilm` and `v17_large` remain explicit
+downloads.
 
 For model artifacts only:
 
@@ -101,7 +102,7 @@ katana artifacts setup --all          # every managed setup model
 katana setup --fast-cpu               # ONNX Runtime dependencies only
 katana setup --torch-cpu              # PyTorch CPU dependencies only
 katana setup --proving-ground         # install Proving Ground dependencies
-katana setup --yes --proving-ground   # small ONNX model, ONNX Runtime, plus Proving Ground
+katana setup --yes --proving-ground   # small ONNX model, similarity embedder, ONNX Runtime, plus Proving Ground
 katana setup full                     # managed setup models, setup dependencies, and verification
 ```
 

--- a/scripts/setup_similarity_embedder.py
+++ b/scripts/setup_similarity_embedder.py
@@ -1,16 +1,5 @@
 #!/usr/bin/env python3
-"""Download the torch-free ONNX sentence-embedder used by the Scabbard
-cosine-similarity false-positive softener.
-
-The softener (``hermes_katana.scabbard.similarity_allowlist``) needs a small
-general-purpose sentence encoder that runs under ``onnxruntime`` -- NOT the
-Scabbard zvec embedder (which clusters attacks and is unsafe as an allowlist
-signal), and NOT a torch model (the production gateway venv is torch-free).
-
-This installs ``Xenova/all-MiniLM-L6-v2`` (ONNX export, ~88 MB) into the Scabbard
-artifact cache. If the artifact is absent the softener simply fails closed
-(no softening), so this step is optional but recommended on any deployment that
-wants false-positive relief on benign security-domain content.
+"""Download the ONNX sentence embedder used by the Scabbard similarity softener.
 
 Usage::
 
@@ -18,57 +7,26 @@ Usage::
     # or pin a location:
     KATANA_SIM_EMBEDDER_DIR=/opt/models/minilm-onnx python scripts/setup_similarity_embedder.py
 """
+
 from __future__ import annotations
 
 import os
 import sys
 from pathlib import Path
 
-_REPO = "Xenova/all-MiniLM-L6-v2"
-_FILES = [
-    "onnx/model.onnx",
-    "tokenizer.json",
-    "tokenizer_config.json",
-    "config.json",
-    "special_tokens_map.json",
-    "vocab.txt",
-]
+
+def _skip_setup() -> bool:
+    return str(os.environ.get("HERMES_KATANA_SKIP_SETUP") or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _target_dir() -> Path:
-    override = os.environ.get("KATANA_SIM_EMBEDDER_DIR")
-    if override:
-        return Path(override).expanduser()
+def _main() -> int:
+    if _skip_setup():
+        return 0
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
-    from hermes_katana.artifacts import default_artifact_cache_dir
+    from hermes_katana.scabbard.similarity_embedder_setup import main
 
-    return default_artifact_cache_dir() / "onnx_embedder_allMiniLM"
-
-
-def main() -> int:
-    try:
-        from huggingface_hub import hf_hub_download
-    except ImportError:
-        print("huggingface_hub is required: pip install huggingface_hub", file=sys.stderr)
-        return 1
-
-    dst = _target_dir()
-    dst.mkdir(parents=True, exist_ok=True)
-    print(f"Downloading {_REPO} (ONNX) -> {dst}")
-    for fname in _FILES:
-        try:
-            path = hf_hub_download(repo_id=_REPO, filename=fname, local_dir=str(dst))
-            print(f"  ok  {fname} ({os.path.getsize(path) // 1024} KB)")
-        except Exception as exc:  # noqa: BLE001
-            print(f"  skip {fname}: {type(exc).__name__}: {exc}", file=sys.stderr)
-
-    model = dst / "onnx" / "model.onnx"
-    if not model.is_file():
-        print(f"ERROR: {model} not present after download", file=sys.stderr)
-        return 1
-    print(f"Done. Similarity softener will use: {dst}")
-    return 0
+    return main()
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(_main())

--- a/src/hermes_katana/cli/main.py
+++ b/src/hermes_katana/cli/main.py
@@ -1090,44 +1090,39 @@ def setup(
 def _install_similarity_embedder(*, target_dir: str | None, force: bool) -> None:
     """Download the torch-free ONNX sentence-encoder for the FP softener.
 
-    Thin wrapper around ``scripts/setup_similarity_embedder.py`` so the
-    CLI surfaces failures as proper exit codes and console output.
-    Skips silently if the embedder artifact is already present.
+    ``target_dir`` is the Katana artifact cache root supplied by the CLI; the
+    embedder itself is stored below it in ``onnx_embedder_allMiniLM``.
+    Skips silently when ``HERMES_KATANA_SKIP_SETUP=1`` is set.
     """
-    import subprocess
-    import sys
-
-    from hermes_katana.scabbard.similarity_allowlist import _default_embedder_dir
-
-    embedder_dir = (
-        Path(target_dir).expanduser().resolve() / "onnx_embedder_allMiniLM" if target_dir else _default_embedder_dir()
+    from hermes_katana.scabbard.similarity_embedder_setup import (
+        install_similarity_embedder,
+        verify_similarity_embedder_runtime,
     )
-    if embedder_dir and embedder_dir.is_dir() and any(embedder_dir.iterdir()) and not force:
-        console.print(f"[green]Present[/green] similarity embedder: {embedder_dir}")
-        return
 
-    repo_root = Path(__file__).resolve().parents[3]
-    script = repo_root / "scripts" / "setup_similarity_embedder.py"
-    if not script.is_file():
-        console.print(
-            f"[yellow]Similarity embedder script not found at {script}; "
-            "skipping. The FP softener will fail closed until "
-            "`scripts/setup_similarity_embedder.py` is run manually.[/yellow]"
+    embedder_dir = Path(target_dir).expanduser().resolve() / "onnx_embedder_allMiniLM" if target_dir else None
+    try:
+        result = install_similarity_embedder(target_dir=embedder_dir, force=force)
+    except RuntimeError as exc:
+        err_console.print(
+            f"[yellow]Similarity embedder setup failed: {exc}. "
+            "The FP softener will fail closed until setup succeeds. "
+            "The rest of katana will still work.[/yellow]"
         )
         return
 
-    env = os.environ.copy()
-    if embedder_dir:
-        env["KATANA_SIM_EMBEDDER_DIR"] = str(embedder_dir)
+    if result.skipped:
+        return
+    if result.downloaded_files:
+        console.print(f"[green]Downloaded[/green] similarity embedder: {result.target_dir}")
+    else:
+        console.print(f"[green]Present[/green] similarity embedder: {result.target_dir}")
 
-    console.print("[bold]Installing similarity embedder (ONNX all-MiniLM-L6-v2)[/bold]")
-    result = subprocess.run([sys.executable, str(script)], env=env)
-    if result.returncode != 0:
+    if verify_similarity_embedder_runtime(result.target_dir):
+        console.print("[green]Verified[/green] similarity softener embedder")
+    else:
         err_console.print(
-            "[yellow]Similarity embedder download failed (exit "
-            f"{result.returncode}). The FP softener will fail closed "
-            "until `python scripts/setup_similarity_embedder.py` is run "
-            "manually. The rest of katana will still work.[/yellow]"
+            "[yellow]Similarity embedder files are present, but runtime verification failed. "
+            "Check ONNX Runtime/transformers dependencies; the FP softener will fail closed.[/yellow]"
         )
 
 

--- a/src/hermes_katana/hermes_plugin.py
+++ b/src/hermes_katana/hermes_plugin.py
@@ -128,7 +128,7 @@ def register(context: Any) -> None:
     # (PR #44) cannot run because the ONNX embedder artifact is missing.
     # The softener fails closed (no FP relief) when the embedder is
     # absent, which is correct but invisible to the user. Operators
-    # can fix this by running `katana artifacts setup` or
+    # can fix this by running `katana setup --yes` or
     # `python scripts/setup_similarity_embedder.py`.
     try:
         from hermes_katana.scabbard.similarity_allowlist import SimilarityAllowlist
@@ -140,10 +140,8 @@ def register(context: Any) -> None:
                 logging.WARNING,
                 "scabbard_similarity_softener_no_op",
                 reason=(
-                    "Cosine-similarity FP softener is enabled but the ONNX "
-                    "all-MiniLM-L6-v2 embedder is not installed. The softener "
-                    "will fail closed (no FP relief). Run `katana artifacts setup` "
-                    "or `python scripts/setup_similarity_embedder.py` to install."
+                    "Similarity softener embedder missing; FP relief disabled. "
+                    "Run `katana setup --yes` or setup_similarity_embedder.py."
                 ),
                 fail_closed=False,
             )

--- a/src/hermes_katana/scabbard/similarity_allowlist.py
+++ b/src/hermes_katana/scabbard/similarity_allowlist.py
@@ -59,6 +59,7 @@ _UNTRUSTED_ORIGINS = frozenset(
         "tool_result",
         "retrieved",
         "retrieved_web",
+        "web_search",
         "rag",
         "web",
         "remote",

--- a/src/hermes_katana/scabbard/similarity_embedder_setup.py
+++ b/src/hermes_katana/scabbard/similarity_embedder_setup.py
@@ -1,0 +1,180 @@
+"""Install and verify the ONNX sentence embedder used by the similarity softener."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+_REPO = "Xenova/all-MiniLM-L6-v2"
+_ENV_TARGET = "KATANA_SIM_EMBEDDER_DIR"
+_ENV_SKIP_SETUP = "HERMES_KATANA_SKIP_SETUP"
+_DEFAULT_EMBEDDER_SUBDIR = "onnx_embedder_allMiniLM"
+_FILES = (
+    "onnx/model.onnx",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "config.json",
+    "special_tokens_map.json",
+    "vocab.txt",
+)
+
+
+@dataclass(frozen=True)
+class SimilarityEmbedderSetupResult:
+    """Outcome from a similarity embedder setup attempt."""
+
+    target_dir: Path
+    downloaded_files: tuple[str, ...] = ()
+    skipped: bool = False
+    ready: bool = False
+    message: str = ""
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def resolve_similarity_embedder_dir(target_dir: str | Path | None = None) -> Path:
+    """Return the concrete directory that should contain the ONNX embedder files."""
+    if target_dir is not None:
+        return Path(target_dir).expanduser().resolve()
+    override = os.environ.get(_ENV_TARGET)
+    if override:
+        return Path(override).expanduser().resolve()
+
+    from hermes_katana.artifacts import default_artifact_cache_dir
+
+    return default_artifact_cache_dir() / _DEFAULT_EMBEDDER_SUBDIR
+
+
+def missing_similarity_embedder_files(target_dir: str | Path | None = None) -> tuple[str, ...]:
+    """Return required embedder files that are absent from ``target_dir``."""
+    target = resolve_similarity_embedder_dir(target_dir)
+    return tuple(rel for rel in _FILES if not (target / rel).is_file())
+
+
+def similarity_embedder_files_present(target_dir: str | Path | None = None) -> bool:
+    """Return True when all files needed to load the similarity embedder exist."""
+    return not missing_similarity_embedder_files(target_dir)
+
+
+def install_similarity_embedder(
+    *,
+    target_dir: str | Path | None = None,
+    force: bool = False,
+) -> SimilarityEmbedderSetupResult:
+    """Download the torch-free all-MiniLM ONNX embedder into ``target_dir``.
+
+    The installer is intentionally explicit and fail-closed: it only performs a
+    network download when called, it honors ``HERMES_KATANA_SKIP_SETUP=1``, and
+    it reports an incomplete artifact instead of treating a non-empty directory
+    as ready.
+    """
+    target = resolve_similarity_embedder_dir(target_dir)
+    if _truthy(os.environ.get(_ENV_SKIP_SETUP)):
+        return SimilarityEmbedderSetupResult(
+            target_dir=target,
+            skipped=True,
+            ready=similarity_embedder_files_present(target),
+            message=f"{_ENV_SKIP_SETUP} is set",
+        )
+
+    if not force and similarity_embedder_files_present(target):
+        return SimilarityEmbedderSetupResult(
+            target_dir=target,
+            ready=True,
+            message="similarity embedder already present",
+        )
+
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as exc:
+        raise RuntimeError("huggingface_hub is required: pip install hermes-katana[fast-cpu]") from exc
+
+    target.mkdir(parents=True, exist_ok=True)
+    token = os.environ.get("KATANA_HF_TOKEN") or os.environ.get("HF_TOKEN")
+    downloaded: list[str] = []
+    for filename in _FILES:
+        try:
+            hf_hub_download(
+                repo_id=_REPO,
+                filename=filename,
+                local_dir=str(target),
+                token=token,
+                force_download=force,
+            )
+        except Exception as exc:
+            raise RuntimeError(f"failed to download {filename} from {_REPO}: {exc}") from exc
+        downloaded.append(filename)
+
+    missing = missing_similarity_embedder_files(target)
+    if missing:
+        raise RuntimeError(f"incomplete similarity embedder at {target}; missing: {', '.join(missing)}")
+
+    return SimilarityEmbedderSetupResult(
+        target_dir=target,
+        downloaded_files=tuple(downloaded),
+        ready=True,
+        message="similarity embedder downloaded",
+    )
+
+
+def verify_similarity_embedder_runtime(target_dir: str | Path | None = None) -> bool:
+    """Return True if the similarity allowlist can load and use the embedder."""
+    target = resolve_similarity_embedder_dir(target_dir)
+    previous = os.environ.get(_ENV_TARGET)
+    os.environ[_ENV_TARGET] = str(target)
+    try:
+        from hermes_katana.scabbard.similarity_allowlist import _allowlist
+
+        # Clear before probing so a temporary KATANA_SIM_EMBEDDER_DIR override
+        # is honored even if the allowlist singleton was already cached.
+        _allowlist.cache_clear()
+        return _allowlist().is_ready()
+    finally:
+        from hermes_katana.scabbard.similarity_allowlist import _allowlist
+
+        # Clear again after restoring the environment so later callers do not
+        # keep using the temporary verification target.
+        _allowlist.cache_clear()
+        if previous is None:
+            os.environ.pop(_ENV_TARGET, None)
+        else:
+            os.environ[_ENV_TARGET] = previous
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target-dir", default=None, help="Directory where the ONNX embedder files should be stored.")
+    parser.add_argument("--force", action="store_true", help="Re-download files even when they already exist.")
+    parser.add_argument("--no-verify", action="store_true", help="Skip runtime verification after download.")
+    args = parser.parse_args(argv)
+
+    try:
+        result = install_similarity_embedder(target_dir=args.target_dir, force=args.force)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    if result.skipped:
+        return 0
+
+    if result.downloaded_files:
+        print(f"Downloaded {_REPO} (ONNX) -> {result.target_dir}")
+        for filename in result.downloaded_files:
+            path = result.target_dir / filename
+            print(f"  ok  {filename} ({path.stat().st_size // 1024} KB)")
+    else:
+        print(f"Present similarity embedder: {result.target_dir}")
+
+    if not args.no_verify and not verify_similarity_embedder_runtime(result.target_dir):
+        print("WARNING: files are present, but the similarity allowlist could not load the embedder.")
+    else:
+        print(f"Done. Similarity softener will use: {result.target_dir}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/smoke/test_short_text_softener.py
+++ b/tests/smoke/test_short_text_softener.py
@@ -196,7 +196,7 @@ class TestShouldSoftenShortText:
 
     def test_untrusted_origin_is_never_softened(self):
         text = "This module documents how the Scabbard classifier detects prompt-injection."
-        for origin in ("tool_output", "tool:read_file", "retrieved_web", "https://example.invalid"):
+        for origin in ("tool_output", "tool:read_file", "retrieved_web", "web_search", "https://example.invalid"):
             should, reason = should_soften_short_text(text, origin=origin)
             assert not should
             assert reason == "untrusted_origin"

--- a/tests/smoke/test_similarity_allowlist_safety.py
+++ b/tests/smoke/test_similarity_allowlist_safety.py
@@ -122,6 +122,7 @@ def test_tainted_origin_never_softened(embedder_ready):
         "tool:read_file",
         "retrieved",
         "retrieved_web",
+        "web_search",
         "web",
         "https://example.invalid",
         "untrusted",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 from io import StringIO
 from types import SimpleNamespace
 from pathlib import Path
@@ -20,7 +19,7 @@ import hermes_katana.cli.main as cli_main
 import hermes_katana.config as config_mod
 import hermes_katana.installer as installer_mod
 import hermes_katana.proxy as proxy_mod
-import hermes_katana.scabbard.similarity_allowlist as similarity_allowlist_mod
+import hermes_katana.scabbard.similarity_embedder_setup as similarity_embedder_setup_mod
 
 
 def _test_console(stream: StringIO) -> Console:
@@ -707,23 +706,51 @@ class TestCLIContracts:
         stderr = StringIO()
         monkeypatch.setattr(cli_main, "console", _test_console(stdout))
         monkeypatch.setattr(cli_main, "err_console", _test_console(stderr))
-        default_dir = tmp_dir / "default" / "onnx_embedder_allMiniLM"
-        default_dir.mkdir(parents=True)
-        (default_dir / "model.onnx").write_text("present", encoding="utf-8")
         target_dir = tmp_dir / "target"
         calls = []
 
-        def fake_run(cmd, *, env):
-            calls.append((cmd, env))
-            return SimpleNamespace(returncode=0)
+        def fake_install(*, target_dir, force):
+            calls.append((target_dir, force))
+            return similarity_embedder_setup_mod.SimilarityEmbedderSetupResult(
+                target_dir=Path(target_dir),
+                downloaded_files=("onnx/model.onnx",),
+                ready=True,
+            )
 
-        monkeypatch.setattr(similarity_allowlist_mod, "_default_embedder_dir", lambda: default_dir)
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(similarity_embedder_setup_mod, "install_similarity_embedder", fake_install)
+        monkeypatch.setattr(
+            similarity_embedder_setup_mod, "verify_similarity_embedder_runtime", lambda target_dir: True
+        )
 
         cli_main._install_similarity_embedder(target_dir=str(target_dir), force=False)
 
-        assert calls
-        assert calls[0][1]["KATANA_SIM_EMBEDDER_DIR"] == str((target_dir / "onnx_embedder_allMiniLM").resolve())
+        assert calls == [((target_dir / "onnx_embedder_allMiniLM").resolve(), False)]
+
+    def test_similarity_embedder_setup_respects_skip_env(self, monkeypatch, tmp_dir):
+        monkeypatch.setenv("HERMES_KATANA_SKIP_SETUP", "1")
+        target_dir = tmp_dir / "embedder"
+
+        result = similarity_embedder_setup_mod.install_similarity_embedder(target_dir=target_dir)
+
+        assert result.skipped
+        assert result.target_dir == target_dir.resolve()
+
+    def test_similarity_embedder_files_present_requires_all_files(self, tmp_dir):
+        target_dir = tmp_dir / "embedder"
+        (target_dir / "onnx").mkdir(parents=True)
+        (target_dir / "onnx" / "model.onnx").write_text("present", encoding="utf-8")
+
+        assert not similarity_embedder_setup_mod.similarity_embedder_files_present(target_dir)
+        assert "tokenizer.json" in similarity_embedder_setup_mod.missing_similarity_embedder_files(target_dir)
+
+    def test_similarity_embedder_runtime_verifies_installed_cache(self):
+        missing = similarity_embedder_setup_mod.missing_similarity_embedder_files()
+        if missing:
+            pytest.skip(f"similarity embedder artifact not installed: {', '.join(missing)}")
+        pytest.importorskip("onnxruntime")
+        pytest.importorskip("transformers")
+
+        assert similarity_embedder_setup_mod.verify_similarity_embedder_runtime()
 
     def test_setup_fast_cpu_installs_extra_without_artifact_choice(self, monkeypatch, tmp_dir):
         stdout = StringIO()

--- a/tests/unit/test_hermes_plugin.py
+++ b/tests/unit/test_hermes_plugin.py
@@ -195,6 +195,35 @@ class TestPluginSetup:
         assert hermes_plugin._initialization_error == "boom"
         assert "pre_tool_call" in ctx.hooks
 
+    def test_similarity_softener_warning_points_to_katana_setup(self, monkeypatch, caplog):
+        ctx = MockPluginContext(config={"audit_enabled": False})
+        monkeypatch.setattr(hermes_plugin, "_initialize_runtime", lambda _config: (None, None, None, None))
+
+        class MissingSimilarityEmbedder:
+            def enabled(self):
+                return True
+
+            def is_ready(self):
+                return False
+
+        monkeypatch.setattr(
+            "hermes_katana.scabbard.similarity_allowlist.SimilarityAllowlist",
+            MissingSimilarityEmbedder,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="hermes_katana.hermes_plugin"):
+            hermes_plugin.setup(ctx)
+
+        record = next(
+            record
+            for record in caplog.records
+            if getattr(record, "katana_event", "") == "scabbard_similarity_softener_no_op"
+        )
+        reason = record.katana_payload["reason"]
+        assert "katana setup --yes" in reason
+        assert "setup_similarity_embedder.py" in reason
+        assert "katana artifacts setup" not in reason
+
     def test_initialize_runtime_uses_passed_config(self, monkeypatch):
         captured: dict[str, Any] = {}
         import hermes_katana.middleware.integration as integration_mod


### PR DESCRIPTION
## Summary

This follows up on the 2026-06-17 audit notes for PRs #44/#45/#46.

- Treat `web_search` as an untrusted origin for both structural and similarity softeners.
- Move the similarity-softener ONNX embedder installer into packaged code so `katana setup` works outside a source checkout.
- Preserve the legacy setup script as a thin wrapper, including a quiet `HERMES_KATANA_SKIP_SETUP=1` path.
- Verify complete embedder file presence instead of accepting any non-empty directory.
- Update plugin/operator guidance so the missing-embedder warning points to `katana setup --yes`, and clarify docs.
- Add an explicit installed-cache runtime verification smoke for the similarity embedder.

## Root Cause

The audit found that `web_search` was omitted from `_UNTRUSTED_ORIGINS`, and the similarity embedder setup path still depended on source-tree script discovery. A wheel install could therefore leave the cosine softener silently unavailable unless the operator knew to run the standalone script from a checkout.

## Validation

- `python -m ruff format --check src/ tests/` → passed
- `python -m ruff check src/ tests/` → passed
- `python -m pytest tests/unit/test_cli.py tests/unit/test_hermes_plugin.py tests/smoke/test_short_text_softener.py tests/smoke/test_similarity_allowlist_safety.py -q` → `214 passed`
- `python -m pytest tests/ -q --tb=short` → `4643 passed, 93 skipped, 1 xfailed`
- `python tests/integration/test_deep_fp_audit.py` → `2200 calls, 0 HARD FPs, 17 SOFT FPs`, `PASS`
- `git diff --check` → passed
- Wheel packaging smoke verified `hermes_katana/scabbard/similarity_embedder_setup.py` is included
- `HERMES_KATANA_SKIP_SETUP=1 python scripts/setup_similarity_embedder.py` exits silently
- `python -m hermes_katana.cli.main audit verify` → `Audit trail integrity verified.`

## Notes

The optional corpus warnings for `training/scanner_data/aho_patterns.txt` and `bloom_phrases_en.txt` still appear locally. That matches the audit's P3 informational note and is not changed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated setup guidance to clarify that the similarity embedder is installed with `katana setup --yes` and `katana setup full`.

* **Changes**
  * Web search results are now treated as untrusted and won't trigger similarity softening.

* **Improvements**
  * Refined similarity embedder installation process and updated setup warnings to guide users to `katana setup --yes`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->